### PR TITLE
Use pip to install/package.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,13 +10,15 @@ source:
   sha256: 034871fae8935de0b38a613e162dab2382da71ff7b182f34f78f595cafc4a670
 
 build:
-  number: 0
+  number: 1
   noarch: python
-  script: python setup.py install
+  script: python -m pip install --no-deps --ignore-installed .
 
 requirements:
-  build:
+  host:
+    - pip
     - python
+    - setuptools
   run:
     - python
 


### PR DESCRIPTION
Closes #2. For reasons unknown to me, not using pip to install/package a
noarch python module can sometimes leave the scripts in the package
without a execute bit. When these packages are installed, the script
cannot be executed without prefixing python:
```
python /path/to/bin/pyxbgen
```

This commit changes the meta.yaml file to use pip to install/package
pyxb. It also adds pip and setuptools to the requirements for building.